### PR TITLE
update carbon identity version range in pom.xml

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-m2
         with:

--- a/component/provisioning-connector/pom.xml
+++ b/component/provisioning-connector/pom.xml
@@ -84,8 +84,7 @@
                             org.wso2.carbon.identity.provisioning.duo.internal
                         </Private-Package>
                         <Import-Package>
-                            !org.wso2.carbon.identity.provisioning.duo.*,
-                            org.wso2.carbon.identity.provisioning.*;version="${carbon.identity.version.range}",
+                            org.wso2.carbon.identity.provisioning;version="${carbon.identity.version.range}",
                             org.wso2.carbon.idp.mgt.*;version="${carbon.identity.version.range}",
                             org.wso2.carbon.identity.application.common.*;version="${carbon.identity.version.range}",
                             org.wso2.carbon.identity.application.mgt.*;version="${carbon.identity.version.range}",

--- a/component/provisioning-connector/pom.xml
+++ b/component/provisioning-connector/pom.xml
@@ -84,6 +84,11 @@
                             org.wso2.carbon.identity.provisioning.duo.internal
                         </Private-Package>
                         <Import-Package>
+                            !org.wso2.carbon.identity.provisioning.duo.*,
+                            org.wso2.carbon.identity.provisioning.*;version="${carbon.identity.version.range}",
+                            org.wso2.carbon.idp.mgt.*;version="${carbon.identity.version.range}",
+                            org.wso2.carbon.identity.application.common.*;version="${carbon.identity.version.range}",
+                            org.wso2.carbon.identity.application.mgt.*;version="${carbon.identity.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <!--Carbon identity version-->
         <carbon.identity.version>5.17.5</carbon.identity.version>
+        <carbon.identity.version.range>[5.17.5,8.0.0)</carbon.identity.version.range>
         <!-- Carbon kernel version -->
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <commons-logging.version>4.4.3</commons-logging.version>


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/26616

## Purpose
This pull request updates the provisioning connector module to improve package import version management and ensure compatibility with a range of Carbon Identity versions. The changes primarily affect Maven configuration files.

Dependency and package import updates:

* Added a new property, `carbon.identity.version.range`, to the root `pom.xml` to define an explicit version range for Carbon Identity dependencies.
* Updated the `Import-Package` section in `component/provisioning-connector/pom.xml` to use the new `carbon.identity.version.range` property for several key packages, ensuring compatibility across a range of Carbon Identity versions.